### PR TITLE
Convert float16 data to 2 byte array

### DIFF
--- a/parquetify/src/main/java/GenerateParquet.java
+++ b/parquetify/src/main/java/GenerateParquet.java
@@ -400,6 +400,21 @@ public class GenerateParquet {
                         isUUID = true;
                     }
 
+                    if ("FLOAT16".equalsIgnoreCase(fieldLogicalType)) {
+                        if (nestedValue instanceof Number) {
+                            float floatValue = ((Number) nestedValue).floatValue();
+                            int intBits = Float.floatToIntBits(floatValue);
+                            short shortBits = (short) (intBits >> 16);
+                            byte[] float16Bytes = new byte[2];
+                            float16Bytes[0] = (byte) (shortBits >> 8);
+                            float16Bytes[1] = (byte) shortBits;
+                            nestedValue = float16Bytes;
+                        } else {
+                            throw new IllegalArgumentException(
+                                    "Invalid value type for FLOAT16 logical type: " + nestedValue.getClass().getName());
+                        }
+                    }
+
                     appendValueToGroup(nestedGroup, nestedFieldName, nestedValue, isUUID);
                 }
             } else {
@@ -414,6 +429,21 @@ public class GenerateParquet {
 
                 if ((fieldLogicalType).equalsIgnoreCase("uuid")) {
                     isUUID = true;
+                }
+
+                if ("FLOAT16".equalsIgnoreCase(fieldLogicalType)) {
+                    if (value instanceof Number) {
+                        float floatValue = ((Number) value).floatValue();
+                        int intBits = Float.floatToIntBits(floatValue);
+                        short shortBits = (short) (intBits >> 16);
+                        byte[] float16Bytes = new byte[2];
+                        float16Bytes[0] = (byte) (shortBits >> 8);
+                        float16Bytes[1] = (byte) shortBits;
+                        value = float16Bytes;
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Invalid value type for FLOAT16 logical type: " + value.getClass().getName());
+                    }
                 }
 
                 appendValueToGroup(group, name, value, isUUID);

--- a/parquetify/src/schema-example/json/float16.json
+++ b/parquetify/src/schema-example/json/float16.json
@@ -1,0 +1,32 @@
+{
+    "fileName": "float16.parquet",
+    "options": {
+        "writerVersion": "1.0",
+        "compression": "GZIP",
+        "rowGroupSize": 256,
+        "pageSize": 1024
+    },
+    "schema": [
+        {
+            "name": "floatfield",
+            "schemaType": "required",
+            "physicalType": "FIXED_LEN_BYTE_ARRAY",
+            "length": 2,
+            "logicalType": "FLOAT16",
+            "data": [
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
PR for #3 

With the changes so far, the file is written without errors. However, the file is unreadable by Clickhouse. Other parquet readers indicate that `logical_type: FLOAT16` is missing from the metadata.